### PR TITLE
Fix Some Bug in Student and Staff Class

### DIFF
--- a/TestSuite/checkpoint/andela/main/BookTest.java
+++ b/TestSuite/checkpoint/andela/main/BookTest.java
@@ -8,13 +8,12 @@ import static org.junit.Assert.*;
  */
 public class BookTest {
   Book book1 = new Book("God are not to blame","Chinua Achebe", 5, "ISBN:08798-48");
-  Book book2 = new Book();
 
   @Test
   public void testSetBookTitle() throws Exception {
-    assertEquals(book2.getBookTitle(),null);
-    book2.setBookTitle("Die another day");
-    assertEquals(book2.getBookTitle(),"Die another day");
+    assertEquals(book1.getBookTitle(),"God are not to blame");
+    book1.setBookTitle("Die another day");
+    assertEquals(book1.getBookTitle(),"Die another day");
   }
 
   @Test
@@ -25,17 +24,23 @@ public class BookTest {
 
   @Test
   public void testSetBookAuthor() throws Exception {
-    book2.setBookAuthor("Wole Soyinka");
-    assertEquals(book2.getBookAuthor(),"Wole Soyinka");
+    book1.setBookAuthor("Wole Soyinka");
+    assertEquals(book1.getBookAuthor(),"Wole Soyinka");
   }
 
 
   @Test
   public void testDecrementBook() throws Exception {
     book1.decrementBook();
-    book2.decrementBook();
     assertEquals(book1.getNumberOfCopies(), 4);
-    assertEquals(book2.getNumberOfCopies(), 0);
+  }
+
+  // Test decrementBook() when the book is not currently available;
+  @Test
+  public void testDecrementBook2() throws Exception {
+    book1.setNumberOfCopies(0);
+    book1.decrementBook();
+    assertEquals(book1.getNumberOfCopies(), 0);
   }
 
   @Test

--- a/TestSuite/checkpoint/andela/members/StaffTest.java
+++ b/TestSuite/checkpoint/andela/members/StaffTest.java
@@ -1,28 +1,35 @@
 package checkpoint.andela.members;
 
 import checkpoint.andela.main.Book;
+import checkpoint.andela.readersClub.ReadersClubManagement;
 import org.junit.Test;
-import static org.junit.Assert.*;
+
+import static org.junit.Assert.assertEquals;
 
 /**
  * Created by Semiu on 26/11/2015.
  */
 public class StaffTest {
   Staff staff1 = new Staff();
-  Book book3 = new Book();
+  Book book1 = new Book();
 
 
   @Test
   public void testBorrowBook() throws Exception {
-    book3.setNumberOfCopies(2);
-    staff1.borrowBook(book3);
-    assertEquals(book3.getNumberOfCopies(), 1);
+    ReadersClubManagement.books.add(book1);
+    book1.setNumberOfCopies(2);
+    staff1.borrowBook(book1);
+    assertEquals(book1.getNumberOfCopies(), 1);
+    ReadersClubManagement.bookBorrowingQueue.clear();
+    ReadersClubManagement.books.clear();
   }
 
   @Test
   public void testReturnBook() throws Exception {
-    book3.setNumberOfCopies(1);
-    staff1.returnBook(book3);
-    assertEquals(book3.getNumberOfCopies(), 2);
+    book1.setNumberOfCopies(1);
+    staff1.returnBook(book1);
+    assertEquals(book1.getNumberOfCopies(), 2);
+    ReadersClubManagement.bookReturningQueue.clear();
+    ReadersClubManagement.books.clear();
   }
 }

--- a/TestSuite/checkpoint/andela/members/StudentTest.java
+++ b/TestSuite/checkpoint/andela/members/StudentTest.java
@@ -1,28 +1,34 @@
 package checkpoint.andela.members;
 
-import org.junit.Test;
 import checkpoint.andela.main.Book;
+import checkpoint.andela.readersClub.ReadersClubManagement;
+import org.junit.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 /**
  * Created by Semiu on 26/11/2015.
  */
 public class StudentTest {
   Student student1 = new Student();
-  Book book4 = new Book();
+  Book book1 = new Book();
 
   @Test
   public void testBorrowBook() throws Exception {
-    book4.setNumberOfCopies(10);
-    student1.borrowBook(book4);
-    assertEquals(book4.getNumberOfCopies(), 9);
+    ReadersClubManagement.books.add(book1);
+    book1.setNumberOfCopies(10);
+    student1.borrowBook(book1);
+    assertEquals(book1.getNumberOfCopies(), 9);
+    ReadersClubManagement.bookBorrowingQueue.clear();
+    ReadersClubManagement.books.clear();
   }
 
   @Test
   public void testReturnBook() throws Exception {
-    book4.setNumberOfCopies(9);
-    student1.returnBook(book4);
-    assertEquals(book4.getNumberOfCopies(), 10);
+    book1.setNumberOfCopies(9);
+    student1.returnBook(book1);
+    assertEquals(book1.getNumberOfCopies(), 10);
+    ReadersClubManagement.bookReturningQueue.clear();
+    ReadersClubManagement.books.clear();
   }
 }

--- a/TestSuite/checkpoint/andela/readersClub/ComparatorInterfaceTest.java
+++ b/TestSuite/checkpoint/andela/readersClub/ComparatorInterfaceTest.java
@@ -14,7 +14,6 @@ import static org.junit.Assert.assertEquals;
 public class ComparatorInterfaceTest {
   Staff staff0 = new Staff();
   Staff staff1 = new Staff();
-  // Pause Script for half second
   {
     try {
       Thread.sleep(500);
@@ -33,34 +32,34 @@ public class ComparatorInterfaceTest {
   }
   Student student2 = new Student();
   Student student3 = new Student();
-  ComparatorInterface test = new ComparatorInterface();
+  ComparatorInterface myComparator = new ComparatorInterface();
 
   // Test that it returns -1 if the first member has higher
   // precedence over the second member
   @Test
   public void testCompare() throws Exception {
-    assertEquals(test.compare(staff1, staff2), -1);
-    assertEquals(test.compare(staff1, student1), -1);
-    assertEquals(test.compare(staff2, student1), -1);
-    assertEquals(test.compare(student1, student2), -1);
+    assertEquals(myComparator.compare(staff1, staff2), -1);
+    assertEquals(myComparator.compare(staff1, student1), -1);
+    assertEquals(myComparator.compare(staff2, student1), -1);
+    assertEquals(myComparator.compare(student1, student2), -1);
   }
 
   // Test that it returns 1 if the second member has higher
   // precedence over the first member
   @Test
   public void testCompare2() throws Exception {
-    assertEquals(test.compare(staff2, staff1), 1);
-    assertEquals(test.compare(student3, staff1), 1);
-    assertEquals(test.compare(student1, staff2), 1);
-    assertEquals(test.compare(student2, student1), 1);
+    assertEquals(myComparator.compare(staff2, staff1), 1);
+    assertEquals(myComparator.compare(student3, staff1), 1);
+    assertEquals(myComparator.compare(student1, staff2), 1);
+    assertEquals(myComparator.compare(student2, student1), 1);
   }
 
   // Test that it returns 0
   // if the two members are equal in status and rank.
   @Test
   public void testCompare3() throws Exception {
-    assertEquals(test.compare(staff0, staff1), 0);
-    assertEquals(test.compare(student2, student3), 0);
+    assertEquals(myComparator.compare(staff0, staff1), 0);
+    assertEquals(myComparator.compare(student2, student3), 0);
   }
 
 }

--- a/src/checkpoint/andela/main/Book.java
+++ b/src/checkpoint/andela/main/Book.java
@@ -15,7 +15,7 @@ public class Book {
   public Book(){
     bookTitle = null;
     bookAuthor = null;
-    numberOfCopies = 0;
+    numberOfCopies = 5;
     isbnNumber = null;
   }
 

--- a/src/checkpoint/andela/main/Member.java
+++ b/src/checkpoint/andela/main/Member.java
@@ -1,13 +1,14 @@
 package checkpoint.andela.main;
 
+import checkpoint.andela.readersClub.ReadersClubManagement;
+
 import java.util.Date;
 
 /**
  * Created by Semiu on 26/11/2015.
  * This Member class is an abstract class.
- * It servws as the parent class to the Staff and Student classes.
- * It contains two abstract methods which must be implemented
- * by any class inheriting it.
+ * It serves as the parent class to the Staff and Student classes.
+ * It contains two abstract methods which must be implemented by it's subclass.
  *
  */
 public abstract class Member {
@@ -35,7 +36,7 @@ public abstract class Member {
     setDateOfBirth(dateOfBirth);
     setEmail(email);
     setPhoneNumber(phoneNumber);
-    setRegistrationDate();
+    registrationDate = setRegistrationDate();
   }
 
   // Setter and Getter for name
@@ -87,7 +88,7 @@ public abstract class Member {
   // These kind of setters are refer to as overloaded method
   public Date setRegistrationDate(){
     this.registrationDate = new Date();
-    return registrationDate;
+    return this.registrationDate;
   }
 
   public Date setRegistrationDate(Date registrationDate){
@@ -105,8 +106,12 @@ public abstract class Member {
   }
 
   // Borrow Book
-  public abstract boolean borrowBook();
+  public void borrowBook(Book book) {
+    ReadersClubManagement.lendingBook(this, book);
+  }
 
   //Return Book
-  public abstract boolean returnBook();
+  public void returnBook(Book book) {
+    ReadersClubManagement.retrieveBook(this, book);
+  }
 }

--- a/src/checkpoint/andela/members/Student.java
+++ b/src/checkpoint/andela/members/Student.java
@@ -4,6 +4,11 @@ import checkpoint.andela.main.Member;
 
 /**
  * Created by Semiu on 26/11/2015.
+ * This class inherit Member class
+ * It also declare two additional properties:
+ * Student-number and student's-class.
+ * Members of this class are given lower precedence compare to
+ * members of Staff class
  */
 public class Student extends Member {
   private int studentNumber;
@@ -37,7 +42,7 @@ public class Student extends Member {
     this.studentClass = studentClass;
   }
 
-  public int gerStaffNetpay() {
+  public int getStudentClass() {
     return studentClass;
   }
 }

--- a/src/checkpoint/andela/readersClub/ReadersClubManagement.java
+++ b/src/checkpoint/andela/readersClub/ReadersClubManagement.java
@@ -75,6 +75,7 @@ public class ReadersClubManagement {
   }
 
   // To determine who get book from the queue
+  // I will still try to work more on this method.
   public static void whoGetBook(Book book) {
     int copies = book.getNumberOfCopies();
     Iterator<Member> iterate = bookBorrowingQueue.iterator();


### PR DESCRIPTION
The Student and Staff Class leaves the book and queue list populated whenever their test is run. 
This causes other test to fail whenever all the tests are run together. 
I added a line of code to clear the list after every execution in order to allow other test to pass. 
